### PR TITLE
Fix the Bid and Ask

### DIFF
--- a/MQL5/Include/mql4compat.mqh
+++ b/MQL5/Include/mql4compat.mqh
@@ -430,9 +430,9 @@ double MarketInfo(string symbol, int type)
       case MODE_TIME:
          return((double)  SymbolInfoInteger(symbol,SYMBOL_TIME));
       case MODE_BID:
-         return(Bid);
+         return (SymbolInfoDouble(symbol, SYMBOL_BID));
       case MODE_ASK:
-         return(Ask);
+         return(SymbolInfoDouble(symbol, SYMBOL_ASK));
       case MODE_POINT:
          return(SymbolInfoDouble(symbol,SYMBOL_POINT));
       case MODE_DIGITS:


### PR DESCRIPTION
Currently, when requesting the Bid and Ask for a symbol, it returns the Bid/Ask of the symbol attached to the chart. For multi-symbol support we need to get the Bid/Ask of the specified symbol, not the one attached to the chart.